### PR TITLE
Built loader for dictionary files

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var express = require('express'),
 var app = express();
 
 var ObjectID = mongodb.ObjectID;
-app.use(bodyParser.json()); // support json encoded bodies
+app.use(bodyParser.json({limit: '50mb'})); // support (large) json encoded bodies
 
 // Create a database variable outside of the database connection callback to reuse the connection pool
 global.db = null;

--- a/test/anagram_client.rb
+++ b/test/anagram_client.rb
@@ -12,7 +12,11 @@ class AnagramClient
   end
 
   def build_uri(path, query=nil)
-    URI::HTTP.new('http', nil, @host, @port, nil, path, nil, query, nil)
+    if @port === "noport"
+      URI::HTTP.new('http', nil, @host, nil, nil, path, nil, query, nil)
+    else
+      URI::HTTP.new('http', nil, @host, @port, nil, path, nil, query, nil)
+    end
   end
 
   def post(path, query=nil, body=nil)

--- a/test/load_dictionary.rb
+++ b/test/load_dictionary.rb
@@ -1,0 +1,10 @@
+require 'json'
+require 'optparse'
+require 'net/http'
+require_relative 'anagram_client'
+
+words = File.readlines('./test/dictionary.txt').each {|l| l.chomp!}
+
+client = AnagramClient.new(ARGV)
+
+client.post('/words.json', nil, {"words" => words })


### PR DESCRIPTION
Wrote a quick ruby script to read a dictionary file like the one
in "test" that uses the anagram client.

Had to update the anagram client for talking to a uri without a
port number.

Also, updated the ability of the service to handle large json
bodies.

Usage: ruby .\test\load_dictionary.rb -n agarmans.herokuapp.com -p noport

"noport" just makes the anagram client pass "nil" for the port
instead of assuming 3000